### PR TITLE
Start Rapid Program Remotely

### DIFF
--- a/abb_driver/config/gofa_cfg.yaml
+++ b/abb_driver/config/gofa_cfg.yaml
@@ -1,5 +1,5 @@
 Gofa:
-  ip_robot: "192.168.131.200"
+  ip_robot: "192.168.15.81"
   # port_robot: 80 for virtual robot (robotstudio)
   port_robot: 443
   name_robot: "ROB_1"

--- a/abb_librws/CMakeLists.txt
+++ b/abb_librws/CMakeLists.txt
@@ -34,6 +34,7 @@ catkin_package(INCLUDE_DIRS include
 ## Build ##
 ###########
 set(SRC_FILES
+    src/executables/start_rapid_program.cpp
     src/rws_client.cpp
     src/rws_common.cpp
     src/rws_interface.cpp
@@ -48,6 +49,23 @@ include_directories(include
 
 add_library(${PROJECT_NAME} ${SRC_FILES})
 target_link_libraries(${PROJECT_NAME} ${Poco_LIBRARIES} ${catkin_LIBRARIES} PocoNet PocoUtil PocoFoundation) #  ACTION 2
+
+
+#############
+##   Exec  ##
+#############
+add_executable(start_rapid_program src/executables/start_rapid_program.cpp)
+target_link_libraries(start_rapid_program
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${Poco_LIBRARIES}
+  PocoNet
+  PocoUtil
+  PocoFoundation
+  PocoNetSSL
+  PocoCrypto
+)
+
 
 #############
 ## Install ##

--- a/abb_librws/include/abb_librws/rws_client.h
+++ b/abb_librws/include/abb_librws/rws_client.h
@@ -363,6 +363,11 @@ public:
   {
     logout();
   }
+  
+  
+  void debugPostAndPrint(const std::string& uri, const std::string& content);
+
+  void debugGetAndPrint(const std::string& uri);
 
   /**
    * \brief A method for retrieving the configuration instances of a type, belonging to a specific configuration topic.
@@ -472,6 +477,20 @@ public:
    * \return RWSResult containing the result.
    */
   RWSResult getPanelOperationMode();
+  
+  /**
+   * \brief A method for setting the operation mode to auto.
+   *
+   * \return RWSResult containing the result.
+   */
+  RWSResult setAutoMode();
+
+  /**
+   * \brief A method for setting the operation mode to manual.
+   *
+   * \return RWSResult containing the result.
+   */
+  RWSResult setManualMode();
 
   /**
    * \brief A method for setting the value of an IO signal.
@@ -650,6 +669,18 @@ public:
    *
    */
   RWSResult releaseMasterShip();
+ 
+  /**
+   * \brief Method for request a mastership on rw domain (motion)
+   *
+   */ 
+  RWSResult requestMasterShipMotion();
+
+  /**
+   * \brief Method for release a mastership on rw domain (motion)
+   *
+   */
+  RWSResult releaseMasterShipMotion();
 
   /**
    * \brief Method for parsing a communication result into a XML document.

--- a/abb_librws/include/abb_librws/rws_common.h
+++ b/abb_librws/include/abb_librws/rws_common.h
@@ -651,6 +651,11 @@ struct SystemConstants
       static const std::string RW_MASTERSHIP;
       
       /**
+       * \brief Mastership.
+       */
+      static const std::string RW_MASTERSHIP_MOTION;
+
+      /**
        * \brief Mechanical units.
        */
       static const std::string RW_MOTIONSYSTEM_MECHUNITS;

--- a/abb_librws/include/abb_librws/rws_interface.h
+++ b/abb_librws/include/abb_librws/rws_interface.h
@@ -450,6 +450,20 @@ public:
    * \return bool indicating if the communication was successful or not.
    */
   bool resetRAPIDProgramPointer();
+  
+  /**
+   * \brief A method for setting the robot to auto mode.
+   *
+   * \return bool indicating if the communication was successful or not.
+   */
+  bool setAutoMode();
+
+  /**
+   * \brief A method for setting the robot to manual mode.
+   *
+   * \return bool indicating if the communication was successful or not.
+   */
+  bool setManualMode();
 
   /**
    * \brief A method for turning on the robot controller's motors.
@@ -579,6 +593,18 @@ public:
    *
    */
   bool releaseMasterShip();
+
+  /**
+   * \brief Method for request a mastership on rw domain (Motion).
+   *
+   */
+  bool requestMasterShipMotion();
+
+  /**
+   * \brief Method for release a mastership on rw domain (Motion).
+   *
+   */
+  bool releaseMasterShipMotion();
 
   /**
    * \brief A method for retrieving the internal log as a text string.

--- a/abb_librws/src/executables/start_rapid_program.cpp
+++ b/abb_librws/src/executables/start_rapid_program.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <abb_librws/rws_interface.h>
+#include <Poco/Net/Context.h>
+
+int main()
+{
+    std::string ip = "192.168.15.81";
+    std::string username = "Admin";
+    std::string password = "robotics";
+
+    // Can only connect locally through MGMT, required to change operating mode
+    bool attempt_local_connect = false;
+
+    // Create Poco SSL context with no verification (self-signed certs likely)
+    const Poco::Net::Context::Ptr ptrContext(new Poco::Net::Context( Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE));
+    
+    // Create RWS interface
+    abb::rws::RWSInterface rws_interface(ip, username, password, ptrContext);
+
+    // Turn off existing processes
+    std::cout << "program off: " << rws_interface.stopRAPIDExecution() << std::endl;
+    std::cin.get();
+    if (attempt_local_connect) {
+        std::cout << "requesting local user registration: " << rws_interface.registerLocalUser("Admin", "ExternalApplication", "ExternalLocation") << std::endl;
+        std::cout << "set to auto mode: " << rws_interface.setAutoMode() << std::endl;
+    }
+
+    // turn motors on
+    std::cout << "set motors on: " << rws_interface.setMotorsOn() << std::endl;
+    std::cin.get();
+
+    // Request MasterShip (Required to reset program pointer)
+    std::cout << "requesting mastership: " << rws_interface.requestMasterShip() << std::endl;
+    std::cin.get();
+
+    std::cout << "reset pointer to main status: " << rws_interface.resetRAPIDProgramPointer() << std::endl;
+    std::cin.get();
+    
+    std::cout << "releasing mastership: " << rws_interface.releaseMasterShip() << std::endl;
+    std::cin.get();
+
+    // start program
+    std::cout << "program on status: " << rws_interface.startRAPIDExecution() << std::endl;
+    std::cin.get();
+
+
+    return 0;
+}
+

--- a/abb_librws/src/rws_client.cpp
+++ b/abb_librws/src/rws_client.cpp
@@ -108,6 +108,26 @@ void RWSClient::SubscriptionResources::add(const std::string resource_uri, const
  * Primary methods
  */
 
+void RWSClient::debugPostAndPrint(const std::string& uri, const std::string& content)
+{
+  POCOResult result = httpPost(uri, content);
+  
+  std::cout << "Request URI: " << uri << std::endl;
+  std::cout << "Request Content: " << content << std::endl;
+  std::cout << "HTTP Status: " << result.poco_info.http.response.status << std::endl;
+  std::cout << "Response Content:\n" << result.poco_info.http.response.content << std::endl;
+}
+
+void RWSClient::debugGetAndPrint(const std::string& uri)
+{
+  POCOResult result = httpGet(uri);
+
+  std::cout << "Request URI: " << uri << std::endl;
+  std::cout << "HTTP Status: " << result.poco_info.http.response.status << std::endl;
+  std::cout << "Response Content:\n" << result.poco_info.http.response.content << std::endl;
+}
+
+
 RWSClient::RWSResult RWSClient::getConfigurationInstances(const std::string topic, const std::string type)
 {
   uri_ = generateConfigurationPath(topic, type) + Resources::INSTANCES;
@@ -219,6 +239,31 @@ RWSClient::RWSResult RWSClient::getPanelOperationMode()
 
   return evaluatePOCOResult(httpGet(uri_), evaluation_conditions_);
 }
+
+RWSClient::RWSResult RWSClient::setAutoMode()
+{
+  uri_ = Resources::RW_PANEL_OPMODE;
+  content_ = "opmode=auto";
+  
+  evaluation_conditions_.reset();
+  evaluation_conditions_.parse_message_into_xml = true;
+  evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
+
+  return evaluatePOCOResult(httpPost(uri_, content_), evaluation_conditions_);
+}
+
+RWSClient::RWSResult RWSClient::setManualMode()
+{
+  uri_ = Resources::RW_PANEL_OPMODE;
+  content_ = "opmode=man";
+
+  evaluation_conditions_.reset();
+  evaluation_conditions_.parse_message_into_xml = true;
+  evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
+  
+  return evaluatePOCOResult(httpPost(uri_, content_), evaluation_conditions_);
+}
+
 
 RWSClient::RWSResult RWSClient::getRAPIDSymbolData(const RAPIDResource resource)
 {
@@ -345,8 +390,8 @@ RWSClient::RWSResult RWSClient::resetRAPIDProgramPointer()
   evaluation_conditions_.reset();
   evaluation_conditions_.parse_message_into_xml = false;
   evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_NO_CONTENT);
-
-  return evaluatePOCOResult(httpPost(uri_), evaluation_conditions_);
+  
+  return evaluatePOCOResult(httpPost(uri_), evaluation_conditions_); 
 }
 
 RWSClient::RWSResult RWSClient::setMotorsOn()
@@ -530,11 +575,11 @@ RWSClient::RWSResult RWSClient::endSubscription()
 RWSClient::RWSResult RWSClient::logout()
 {
   uri_ = Resources::LOGOUT;
-
+  
   evaluation_conditions_.reset();
   evaluation_conditions_.parse_message_into_xml = true;
   evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
-
+  
   return evaluatePOCOResult(httpGet(uri_), evaluation_conditions_);
 }
 
@@ -552,9 +597,9 @@ RWSClient::RWSResult RWSClient::registerLocalUser(std::string username,
   evaluation_conditions_.parse_message_into_xml = false;
   evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_OK);
   evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_CREATED);
-
-  RWSResult result = evaluatePOCOResult(httpPost(uri_, content_), evaluation_conditions_);
   
+  RWSResult result = evaluatePOCOResult(httpPost(uri_, content_), evaluation_conditions_);
+
   return result;
 }
 
@@ -592,6 +637,28 @@ RWSClient::RWSResult RWSClient::requestMasterShip()
 RWSClient::RWSResult RWSClient::releaseMasterShip()
 {
   uri_ = Resources::RW_MASTERSHIP + "/" + Queries::ACTION_RELEASE;
+
+  evaluation_conditions_.reset();
+  evaluation_conditions_.parse_message_into_xml = false;
+  evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_NO_CONTENT);
+ 
+  return evaluatePOCOResult(httpPost(uri_), evaluation_conditions_);
+}
+
+RWSClient::RWSResult RWSClient::requestMasterShipMotion()
+{
+  uri_ = Resources::RW_MASTERSHIP_MOTION + "/" + Queries::ACTION_REQUEST;
+
+  evaluation_conditions_.reset();
+  evaluation_conditions_.parse_message_into_xml = false;
+  evaluation_conditions_.accepted_outcomes.push_back(HTTPResponse::HTTP_NO_CONTENT);
+
+  return evaluatePOCOResult(httpPost(uri_), evaluation_conditions_);
+}
+
+RWSClient::RWSResult RWSClient::releaseMasterShipMotion()
+{
+  uri_ = Resources::RW_MASTERSHIP_MOTION + "/" + Queries::ACTION_RELEASE;
 
   evaluation_conditions_.reset();
   evaluation_conditions_.parse_message_into_xml = false;

--- a/abb_librws/src/rws_common.cpp
+++ b/abb_librws/src/rws_common.cpp
@@ -261,6 +261,7 @@ const std::string Resources::LEADTHROUGH                      = "/lead-through";
 const std::string Resources::MODULES                          = "/modules";
 const std::string Resources::RW_CFG                           = Services::RW + "/cfg";
 const std::string Resources::RW_IOSYSTEM_SIGNALS              = Services::RW + "/iosystem/signals";
+const std::string Resources::RW_MASTERSHIP_MOTION             = Services::RW + "/mastership/motion";
 const std::string Resources::RW_MASTERSHIP                    = Services::RW + "/mastership/edit";
 const std::string Resources::RW_MOTIONSYSTEM_MECHUNITS        = Services::RW + "/motionsystem/mechunits";
 const std::string Resources::RW_PANEL_CTRLSTATE               = Services::RW + "/panel/ctrl-state";

--- a/abb_librws/src/rws_interface.cpp
+++ b/abb_librws/src/rws_interface.cpp
@@ -229,6 +229,16 @@ bool RWSInterface::resetRAPIDProgramPointer()
   return rws_client_.resetRAPIDProgramPointer().success;
 }
 
+bool RWSInterface::setAutoMode()
+{
+  return rws_client_.setAutoMode().success;
+}
+
+bool RWSInterface::setManualMode()
+{
+  return rws_client_.setManualMode().success;
+}
+
 bool RWSInterface::setMotorsOn()
 {
   return rws_client_.setMotorsOn().success;
@@ -425,6 +435,16 @@ bool RWSInterface::requestMasterShip()
 bool RWSInterface::releaseMasterShip()
 {
   return rws_client_.releaseMasterShip().success;
+}
+
+bool RWSInterface::requestMasterShipMotion()
+{
+  return rws_client_.requestMasterShipMotion().success;
+}
+
+bool RWSInterface::releaseMasterShipMotion()
+{
+  return rws_client_.releaseMasterShipMotion().success;
 }
 
 std::string RWSInterface::getLogText(const bool verbose)


### PR DESCRIPTION
Added File to start rapid program remotely.

Added print functions in the client class

created interface/client/common variables/functions for changing the controller from manual to auto mode, and requesting specifically the motion mastership permission.

One must have local permissions through the MGMT port to change the controller between manual and auto mode.